### PR TITLE
Create a reusable workflow for simplifying workflow reuse

### DIFF
--- a/.github/workflows/woke.yaml
+++ b/.github/workflows/woke.yaml
@@ -62,11 +62,11 @@ jobs:
         uses: canonical-web-and-design/inclusive-naming@main
         with:
           github-token: ${{ secrets.github-token }}
-          workdir: ${{ input.workdir }}
-          level: ${{ input.level }}
-          reporter: ${{ input.reporter }}
-          filter-mode: ${{ input.filter-mode }}
-          fail-on-error: ${{ input.fail-on-error }}
-          reviewdog-flags: ${{ input.reviewdog-flags }}
-          woke-args: ${{ input.woke-args }}
-          woke-version: $${ input.woke-version }}         
+          workdir: ${{ inputs.workdir }}
+          level: ${{ inputs.level }}
+          reporter: ${{ inputs.reporter }}
+          filter-mode: ${{ inputs.filter-mode }}
+          fail-on-error: ${{ inputs.fail-on-error }}
+          reviewdog-flags: ${{ inputs.reviewdog-flags }}
+          woke-args: ${{ inputs.woke-args }}
+          woke-version: $${ inputs.woke-version }}         

--- a/.github/workflows/woke.yaml
+++ b/.github/workflows/woke.yaml
@@ -1,0 +1,78 @@
+on:
+  workflow_call:
+    inputs:
+      workdir:
+        description: 'Working directory relative to the root directory.'
+        type: string
+        required: false
+        default: '.'
+      level:
+        description: 'Report level for reviewdog [info,warning,error]'
+        type: string
+        required: false
+        default: 'error'
+      reporter:
+        description: 'Reporter of reviewdog command [github-pr-check,github-pr-review].'
+        type: string
+        required: false
+        default: 'github-pr-check'
+      filter-mode:
+        description: |
+          Filtering mode for the reviewdog command [added,diff_context,file,nofilter].
+          Default is added.
+        required: false
+        type: choice
+        default: 'added'
+        options:
+        - added
+        - diff_context
+        - file
+        - nofilter
+      fail-on-error:
+        description: |
+          Exit code for reviewdog when errors are found [true,false]
+          Default is `false`.
+        type: string
+        required: false
+        default: 'false'
+      reviewdog-flags:
+        description: 'Additional reviewdog flags'
+        type: string
+        required: false
+        default: ''
+      woke-args:
+        description: 'woke arguments'
+        type: string
+        required: false
+        default: '. -c /home/runner/work/_actions/canonical-web-and-design/inclusive-naming/main/config.yml'
+        required: false
+      woke-version:
+        description: 'woke version, defaults to the latest `v0` version. Override to pin to a specific version'
+        type: string
+        required: false
+        default: 'v0'
+    secrets:
+      github-token:
+        description: 'GITHUB_TOKEN'
+        type: string
+        required: false
+        default: '${{ secrets.GITHUB_TOKEN }}'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: woke
+        uses: canonical-web-and-design/inclusive-naming@main
+        with:
+          github-token: ${{ secrets.github-token }}
+          workdir: ${{ input.workdir }}
+          level: ${{ input.level }}
+          reporter: ${{ input.reporter }}
+          filter-mode: ${{ input.filter-mode }}
+          fail-on-error: ${{ input.fail-on-error }}
+          reviewdog-flags: ${{ input.reviewdog-flags }}
+          woke-args: ${{ input.woke-args }}
+          woke-version: $${ input.woke-version }}         

--- a/.github/workflows/woke.yaml
+++ b/.github/workflows/woke.yaml
@@ -69,4 +69,4 @@ jobs:
           fail-on-error: ${{ inputs.fail-on-error }}
           reviewdog-flags: ${{ inputs.reviewdog-flags }}
           woke-args: ${{ inputs.woke-args }}
-          woke-version: $${ inputs.woke-version }}         
+          woke-version: ${ inputs.woke-version }}         

--- a/.github/workflows/woke.yaml
+++ b/.github/workflows/woke.yaml
@@ -1,52 +1,47 @@
 name: Woke Check
+
 on:
   workflow_call:
     inputs:
       workdir:
         description: 'Working directory relative to the root directory.'
-        type: string
         required: false
+        type: string
         default: '.'
       level:
         description: 'Report level for reviewdog [info,warning,error]'
-        type: string
         required: false
+        type: string
         default: 'error'
       reporter:
         description: 'Reporter of reviewdog command [github-pr-check,github-pr-review].'
-        type: string
         required: false
+        type: string
         default: 'github-pr-check'
       filter-mode:
         description: |
           Filtering mode for the reviewdog command [added,diff_context,file,nofilter].
           Default is added.
         required: false
-        type: choice
+        type: string
         default: 'added'
-        options:
-        - added
-        - diff_context
-        - file
-        - nofilter
       fail-on-error:
         description: |
           Exit code for reviewdog when errors are found [true,false]
           Default is `false`.
-        type: string
         required: false
+        type: string
         default: 'false'
       reviewdog-flags:
         description: 'Additional reviewdog flags'
-        type: string
         required: false
+        type: string
         default: ''
       woke-args:
         description: 'woke arguments'
+        required: false
         type: string
-        required: false
         default: '. -c /home/runner/work/_actions/canonical-web-and-design/inclusive-naming/main/config.yml'
-        required: false
       woke-version:
         description: 'woke version, defaults to the latest `v0` version. Override to pin to a specific version'
         type: string
@@ -55,9 +50,7 @@ on:
     secrets:
       github-token:
         description: 'GITHUB_TOKEN'
-        type: string
         required: false
-        default: '${{ secrets.GITHUB_TOKEN }}'
 
 jobs:
   check:

--- a/.github/workflows/woke.yaml
+++ b/.github/workflows/woke.yaml
@@ -69,4 +69,4 @@ jobs:
           fail-on-error: ${{ inputs.fail-on-error }}
           reviewdog-flags: ${{ inputs.reviewdog-flags }}
           woke-args: ${{ inputs.woke-args }}
-          woke-version: ${ inputs.woke-version }}         
+          woke-version: ${{ inputs.woke-version }}         

--- a/.github/workflows/woke.yaml
+++ b/.github/workflows/woke.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: woke
         uses: canonical-web-and-design/inclusive-naming@main
         with:
-          github-token: ${{ secrets.github-token }}
+          github-token: ${{ secrets.github-token || github.token }}
           workdir: ${{ inputs.workdir }}
           level: ${{ inputs.level }}
           reporter: ${{ inputs.reporter }}

--- a/.github/workflows/woke.yaml
+++ b/.github/workflows/woke.yaml
@@ -1,3 +1,4 @@
+name: Woke Check
 on:
   workflow_call:
     inputs:

--- a/README.md
+++ b/README.md
@@ -12,19 +12,11 @@ name: Inclusive naming PR check
 on: pull_request
 
 jobs:
-  inclusive-naming-check:
-    name: Inclusive-naming-check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: woke
-        uses: petesfrench/inclusive-naming-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          reporter: github-pr-check
-          fail-on-error: true
+  call-inclusive-naming-check:
+    name: Inclusive naming check
+    uses: canonical-web-and-design/Inclusive-naming/.github/workflows/woke.yaml@main
+    with:
+      fail-on-error: "true"
 
 ```
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ on: pull_request
 
 jobs:
   call-inclusive-naming-check:
-    name: Inclusive naming check
+    name: Inclusive naming
     uses: canonical-web-and-design/Inclusive-naming/.github/workflows/woke.yaml@main
     with:
       fail-on-error: "true"


### PR DESCRIPTION
Based on [reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows)

Git-hub workflows are a callable! Once this workflow is updated, all callers are updated at the same time