### PR TITLE
Update `actions/checkout`

### DIFF
--- a/.github/workflows/woke.yaml
+++ b/.github/workflows/woke.yaml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: woke
         uses: canonical-web-and-design/inclusive-naming@main
         with:


### PR DESCRIPTION
## Changes
Node.js 12 actions are [deprecated](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/). This PR updates the checkout version in the inclusive naming reusable workflow to address this issue.