### PR TITLE
Add .woke.yaml and .woke.yml to the ignored files

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,8 @@
 ignore_files:
   - README.md
   - .github
+  - .woke.yaml
+  - .woke.yml
 
 rules:
   # Overtly racist terms


### PR DESCRIPTION
Add .woke.yaml and .woke.yml to the ignored files. We're currently using these files for both
* Running the snap locally
* Merge them with the default configuration file in our pipelines as a mechanism to override the configuration