### PR TITLE
Select jammy instance rather than `ubuntu-latest`

### DIFF
--- a/.github/workflows/woke.yaml
+++ b/.github/workflows/woke.yaml
@@ -3,6 +3,11 @@ name: Woke Check
 on:
   workflow_call:
     inputs:
+      runs-on:
+        description: 'Which ubuntu series should be used for the runner'
+        default: "ubuntu-22.04"
+        required: false
+        type: string
       workdir:
         description: 'Working directory relative to the root directory.'
         required: false
@@ -54,7 +59,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/woke.yaml
+++ b/.github/workflows/woke.yaml
@@ -54,7 +54,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v3


### PR DESCRIPTION
@petesfrench i'm seeing jobs like the following blocking because they cannot use `ubuntu-latest`
* [non-running action](https://github.com/canonical/ops-lib-manifest/actions/runs/5533919258/jobs/10098869461)

[Reference Documentation](https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/)

Update: This may have turned out to be a github issue -- and this change isn't NECESSARY -- but it's also not a bad adjustment either