### PR TITLE
add .wokeignore to exempt files

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -3,6 +3,7 @@ ignore_files:
   - .github
   - .woke.yaml
   - .woke.yml
+  - .wokeignore
 
 rules:
   # Overtly racist terms


### PR DESCRIPTION
.wokeignore is used in the Starter Pack, so all new Documentation sets include it. It contains a non-inclusive word so needs to be exempt from inclusive-language checks. Other woke-related files are exempt already, so this isn't a significant change.