### PR TITLE
Update to actions/checkout@v4

### DIFF
--- a/.github/workflows/woke.yaml
+++ b/.github/workflows/woke.yaml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: woke
         uses: canonical/inclusive-naming@main
         with:


### PR DESCRIPTION
Removes warning


[Inclusive Naming / check](https://github.com/charmed-kubernetes/charm-kubernetes-control-plane/actions/runs/8541179046/job/23406708796)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.