### PR TITLE
Fix default woke args config path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
     default: ''
   woke-args:
     description: 'woke arguments'
-    default: '. -c /home/runner/work/_actions/canonical/inclusive-naming/main/config.yml'
+    default: '. -c ${GITHUB_ACTION_PATH}/config.yml'
     required: false
   woke-version:
     description: 'woke version, defaults to the latest `v0` version. Override to pin to a specific version'

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
     default: ''
   woke-args:
     description: 'woke arguments'
-    default: '. -c /home/runner/work/_actions/canonical-web-and-design/inclusive-naming/main/config.yml'
+    default: '. -c /home/runner/work/_actions/canonical/inclusive-naming/main/config.yml'
     required: false
   woke-version:
     description: 'woke version, defaults to the latest `v0` version. Override to pin to a specific version'


### PR DESCRIPTION
This repository was moved from the `canonical-web-and-design` organization to the `canonical` organization (presumably). This commit updates the expected location of the configuration file by the action runner.

> Error: open /home/runner/work/_actions/canonical-web-and-design/inclusive-naming/main/config.yml: no such file or directory

**References:**
- https://chat.canonical.com/canonical/pl/7ksyzsf7jpn5xnskkdemx17puc
- https://github.com/canonical/360.canonical.com/actions/runs/26574890608/job/78291409960