### PR TITLE
Fix reviewdog fail on error

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,13 +18,18 @@ echo '::group:: Installing woke ... https://github.com/get-woke/woke'
 curl -sfL https://raw.githubusercontent.com/get-woke/woke/main/install.sh | sh -s -- -b "${TEMP_PATH}" "${INPUT_WOKE_VERSION}" 2>&1
 echo '::endgroup::'
 
+FAIL_LEVEL_FLAG=""
+if [ "${INPUT_FAIL_ON_ERROR:-false}" = "true" ]; then
+  FAIL_LEVEL_FLAG="-fail-level=error"
+fi
+
 echo '::group::'
 woke --output simple ${INPUT_WOKE_ARGS} \
   | reviewdog -efm="%f:%l:%c: %m" \
       -name="Inclusive naming check" \
       -reporter="${INPUT_REPORTER:-github-pr-check}" \
       -filter-mode="${INPUT_FILTER_MODE:-added}" \
-      -fail-on-error="${INPUT_FAIL_ON_ERROR:-false}" \
+      ${FAIL_LEVEL_FLAG} \
       -level="${INPUT_LEVEL}" \
       ${INPUT_REVIEWDOG_FLAGS}
 echo '::endgroup::'


### PR DESCRIPTION
This commit replaces [reviewdog](https://github.com/reviewdog/reviewdog)'s `-fail-on-error` with `-fail-level=error`.

> reviewdog: -fail-on-error is deprecated. Use -fail-level=any, or -fail-level=error for github-[pr-]check reporter instead. See also https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md

Note: I didn't use bash expansion because `"false"` will evaluate as set.

**References:**
- https://github.com/reviewdog/reviewdog#exit-codes
- https://chat.canonical.com/canonical/pl/7ksyzsf7jpn5xnskkdemx17puc
- https://github.com/canonical/360.canonical.com/actions/runs/26574890608/job/78291409960