### PR TITLE
Fix woke args path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
     default: ''
   woke-args:
     description: 'woke arguments'
-    default: '. -c ${{ github.action_path }}/config.yml'
+    default: '. -c config.yml'
     required: false
   woke-version:
     description: 'woke version, defaults to the latest `v0` version. Override to pin to a specific version'

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
     default: ''
   woke-args:
     description: 'woke arguments'
-    default: '. -c ${GITHUB_ACTION_PATH}/config.yml'
+    default: '. -c ${{ github.action_path }}/config.yml'
     required: false
   woke-version:
     description: 'woke version, defaults to the latest `v0` version. Override to pin to a specific version'

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
     default: ''
   woke-args:
     description: 'woke arguments'
-    default: '. -c config.yml'
+    default: '.'
     required: false
   woke-version:
     description: 'woke version, defaults to the latest `v0` version. Override to pin to a specific version'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,6 +23,11 @@ if [ "${INPUT_FAIL_ON_ERROR:-false}" = "true" ]; then
   FAIL_LEVEL_FLAG="-fail-level=error"
 fi
 
+# Fallback to the action's internal config if no config flag is provided
+if [[ ! "$INPUT_WOKE_ARGS" =~ "-c" ]] && [[ ! "$INPUT_WOKE_ARGS" =~ "--config" ]]; then
+  INPUT_WOKE_ARGS="$INPUT_WOKE_ARGS -c $GITHUB_ACTION_PATH/config.yml"
+fi
+
 echo '::group::'
 woke --output simple ${INPUT_WOKE_ARGS} \
   | reviewdog -efm="%f:%l:%c: %m" \


### PR DESCRIPTION
This maintains the behavior that existed before, the default configuration will be used if none is specified and will do so dynamically, but does so differently, by checking for `-c`/`--config` immediately before execution.

Based on my best understanding of GitHub Actions, expressions do not work when outside workflow context and are unavailable at runtime. No variable can satisfy this requirement, which is likely why it was hardcoded before.

Short of a rewrite, this appears to be the best available solution. You can check [this run](https://github.com/canonical/360.canonical.com/actions/runs/28598650200/job/84800651307?pr=562) as proof it works.